### PR TITLE
Feature: Link Jira Issues to PR

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!--- Provide a general summary of your changes in the title above -->
+<!--- Include Jira issue number to link PR to Jira -->
+<!--- Example: Feature: Scan Interpretations [FAR-123] -->
 
 ## Description
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@
 ## Card Link
 
 <!--- Add link to JIRA/Trello Card -->
+<!--- Example: [FAR-123] -->
 
 ## Dependent Repos/Branchs/PRs
 


### PR DESCRIPTION
## Description

Updates pull request template to include examples for linking Jira issues to GitHub through PR title.

More information can be found [here](https://github.com/integrations/jira/blob/master/SUPPORT.md#nothing-showing-up-in-jira):

>Next check that you're adding your Jira issue keys in your **commits, branches, or pull request titles**. These are the only places on GitHub where you can put your Jira issue keys that will cause updates to be sent to the Jira issue.

## Summary of Changes

* Updated `PULL_REQUEST_TEMPLATE.md` to include example Jira issue formatting